### PR TITLE
Fix install and versioning, add user-agent

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,8 @@
 [bumpversion]
 commit = True
 current_version = 0.1.0
-files = cert_manager/__init__.py
 tag = True
 tag_name = {new_version}
+
+[bumpversion:file:setup.py]
+[bumpversion:file:cert_manager/__version__.py]

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# global owners
+*       @broadinstitute/devnull

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -61,10 +61,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:39183aecc01d6f74eb54edc6739992e842f3bf3068bdfaaba30b5a1742f44091",
-                "sha256:62bd1d8d2ace3e812b3a22eb3c4b7856536d8cc0cdb37466f6a53cf881dbad1f"
+                "sha256:6560e1e1749f68c64a4b5dee4e091fce798d2f0d84ebe638cf0e0585a343acf4",
+                "sha256:b65db1bbaac9f9f4d190199bb8680af6f6f84fd3769a5ea883df8a91fe68b4c4"
             ],
-            "version": "==2.2.4"
+            "version": "==2.2.5"
         },
         "bleach": {
             "hashes": [
@@ -200,10 +200,10 @@
         },
         "isort": {
             "hashes": [
-                "sha256:89041186651a9a6159683098f337eed0994d9d94e006f891c6e8cbeb8e65f1c7",
-                "sha256:ba51a651505242b0b37ad94b281e1154301e221a40c623e62334ed863fc1c98c"
+                "sha256:38a74a5ccf3a15a7a99f975071164f48d4d10eed4154879009c18e6e8933e5aa",
+                "sha256:abbb2684aa234d5eb8a67ef36d4aa62ea080d46c2eba36ad09e2990ae52e4305"
             ],
-            "version": "==4.3.12"
+            "version": "==4.3.13"
         },
         "lazy-object-proxy": {
             "hashes": [

--- a/cert_manager/__init__.py
+++ b/cert_manager/__init__.py
@@ -7,8 +7,4 @@ from .person import Person
 from .smime import SMIME
 from .ssl import SSL
 
-APP_VERSION = "0.1.0"
-
 __all__ = ["Client", "HttpError", "Organization", "Pending", "Person", "SMIME", "SSL"]
-
-__version__ = APP_VERSION

--- a/cert_manager/__version__.py
+++ b/cert_manager/__version__.py
@@ -1,0 +1,6 @@
+"""Keep track of the version for the cert_manager module."""
+
+__title__ = "cert_manager"
+__description__ = "Python interface to the Sectigo Certificate Manager REST API"
+__url__ = "https://github.com/broadinstitute/python-cert_manager"
+__version__ = "0.1.0"

--- a/cert_manager/_certificates.py
+++ b/cert_manager/_certificates.py
@@ -134,7 +134,8 @@ class Certificates(Endpoint):
         url = self._url("/enroll")
         data = {
             "orgId": org_id, "csr": csr.rstrip(), "subjAltNames": subject_alt_names, "certType": type_id,
-            "numberServers": 1, "serverType": -1, "term": term, "comments": "cert_manager", "externalRequester": ""
+            "numberServers": 1, "serverType": -1, "term": term, "comments": "Enrolled by %s" % self._client.user_agent,
+            "externalRequester": ""
         }
         result = self._client.post(url, data=data)
 

--- a/cert_manager/client.py
+++ b/cert_manager/client.py
@@ -2,9 +2,11 @@
 
 import logging
 import re
+import sys
 
 import requests
 
+from . import __version__
 from ._helpers import HttpError, traffic_log
 
 LOGGER = logging.getLogger(__name__)
@@ -51,6 +53,7 @@ class Client(object):
             "login": self.__username,
             "customerUri": self.__login_uri,
             "Accept": "application/json",
+            "User-Agent": self.user_agent,
         }
 
         # Setup the Session for certificate auth
@@ -72,6 +75,15 @@ class Client(object):
             self.__headers["password"] = self.__password
 
         self.__session.headers.update(self.__headers)
+
+    @property
+    def user_agent(self):
+        """Return a user-agent string including the module version and Python version."""
+        ver_info = list(map(str, sys.version_info))
+        pyver = ".".join(ver_info[:3])
+        useragent = "cert_manager/%s (Python %s)" % (__version__.__version__, pyver)
+
+        return useragent
 
     @property
     def base_url(self):

--- a/setup.py
+++ b/setup.py
@@ -5,14 +5,11 @@
 import io
 import setuptools
 
-from cert_manager import APP_VERSION
-
 
 def get_long_description():
     """Retrieve the long description from the README file."""
     # Use io.open to support encoding on Python 2 and 3
     fileh = io.open("README.md", "r", encoding="utf8")
-    # ld = markdown2.markdown(fh.read())
     desc = fileh.read()
     fileh.close()
 
@@ -21,7 +18,7 @@ def get_long_description():
 
 setuptools.setup(
     name="cert_manager",
-    version=APP_VERSION,
+    version="0.1.0",
     author="Andrew Teixeira",
     author_email="teixeira@broadinstitute.org",
     description="Python interface to the Sectigo Certificate Manager REST API",

--- a/tests/lib/testbase.py
+++ b/tests/lib/testbase.py
@@ -1,8 +1,11 @@
 """Define some basic classes and functions for use in unit tests."""
 
+import sys
+
 import fixtures
 
 from cert_manager.client import Client
+from cert_manager import __version__
 
 
 class ClientFixture(fixtures.Fixture):
@@ -18,15 +21,22 @@ class ClientFixture(fixtures.Fixture):
         self.user_crt_file = "/path/to/pub.key"
         self.user_key_file = "/path/to/priv.key"
 
+        # This is basically the same code as the code used in Client.  This is used just to lock in the
+        # data that the user-agent should have in it.
+        ver_info = list(map(str, sys.version_info))
+        pyver = ".".join(ver_info[:3])
+        self.user_agent = "cert_manager/%s (Python %s)" % (__version__.__version__, pyver)
+
+        # Make a Client object
+        self.client = Client(base_url=self.base_url, login_uri=self.login_uri, username=self.username,
+                             password=self.password)
+
         # Headers to check later
         self.headers = {
             "login": self.username,
             "customerUri": self.login_uri,
             "Accept": "application/json",
+            "User-Agent": self.user_agent,
         }
-
-        # Make a Client object
-        self.client = Client(base_url=self.base_url, login_uri=self.login_uri, username=self.username,
-                             password=self.password)
 
         self.addCleanup(delattr, self, "client")

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -339,8 +339,8 @@ class TestEnroll(TestCertificates):
         # Mock up the data that should be sent with the post
         post_data = {
             "orgId": self.test_org, "csr": self.test_csr.rstrip(), "subjAltNames": None, "certType": 224,
-            "numberServers": 1, "serverType": -1, "term": self.test_term, "comments": "cert_manager",
-            "externalRequester": ""
+            "numberServers": 1, "serverType": -1, "term": self.test_term,
+            "comments": "Enrolled by %s" % self.client.user_agent, "externalRequester": ""
         }
         post_json = json.dumps(post_data)
 


### PR DESCRIPTION
* Added a `CODEOWNERS` file
* Add `cert_manager/__version__.py` to keep track of module info
* Remove version info from `cert_manager/__init__.py`
* Change bump2version config to fix `setup.py` and the new `cert_manager/__version__.py`
* Fix `setup.py` that was broken due to including `cert_manager/__init__.py`
* Update Client to set a reasonable user-agent header
* Update comment on `Certificates.enroll` to include the new user-agent
* Fix all necessary unit tests
Fixes #2 