### PR TITLE
Add support for ACME endpoint(s)

### DIFF
--- a/cert_manager/__init__.py
+++ b/cert_manager/__init__.py
@@ -7,5 +7,6 @@ from .organization import Organization
 from .person import Person
 from .smime import SMIME
 from .ssl import SSL
+from .acme import ACMEAccount
 
-__all__ = ["Client", "Organization", "Pending", "Person", "SMIME", "SSL"]
+__all__ = ["Client", "Organization", "Pending", "Person", "SMIME", "SSL", "ACMEAccount"]

--- a/cert_manager/acme.py
+++ b/cert_manager/acme.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""Define the cert_manager.acme.ACMEAccount class."""
+
+import re
+import logging
+
+from ._endpoint import Endpoint
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ACMEAccountCreationResponseError(Exception):
+    """An error (other than HTTPError) occurred while processing ACME Account Creation API response"""
+
+
+class ACMEAccount(Endpoint):
+    """Query the Sectigo Cert Manager REST API for ACME Account data."""
+    _find_params_to_api = {
+        'org_id': 'organizationId',
+        'name': 'name',
+        'acme_server': 'acmeServer',
+        'cert_validation_type': 'certValidationType',
+        'status': 'status'
+    }
+
+    def __init__(self, client, api_version="v1"):
+        """Initialize the class.
+
+        Note: The *all* method will be run on object instantiation to fetch all acme accounts
+
+        :param object client: An instantiated cert_manager.Client object
+        :param string api_version: The API version to use; the default is "v1"
+        """
+        super().__init__(client=client, endpoint="/acme", api_version=api_version)
+        self._api_url = self._url('/account')
+
+        self.__acme_accounts = None
+
+    def all(self, org_id, force=False):
+        """Return a list of acme accounts from Sectigo.
+
+        :param bool force: If set to True, force refreshing the data from the API
+        :param int org_id: The ID of the organization for which to fetch data
+
+        :return list: A list of dictionaries representing the acme accounts
+        """
+        if (self.__acme_accounts) and (not force):
+            return self.__acme_accounts
+
+        self.__acme_accounts = self.find(org_id)
+
+        return self.__acme_accounts
+
+    def find(self, org_id, **kwargs):
+        """Return a list of acme accounts matching the parameters.
+
+        :param int org_id: The ID of the organization for which to search
+
+        Any other List ACME accounts request parameters can be provided as
+        keyword arguments.
+
+        :return list: A list of dictionaries representing the matched acme accounts
+        """
+        kwargs['org_id'] = org_id
+        params = {
+            self._find_params_to_api[param]: kwargs.get(param)
+            for param in self._find_params_to_api
+        }
+
+        results = []
+
+        for result in self._client.get_paginated(self._api_url, params=params):
+            results += result.json()
+
+        return results
+
+    def get(self, acme_id):
+        """Return a dictionary of acme account information.
+
+        :param int acme_id: The ID of the acme account to query
+
+        return dict: The account information
+        """
+        url = self._url(str(acme_id))
+        result = self._client.get(url)
+
+        return result.json()
+
+    def create(self, name, acme_server, org_id, ev_details=None):
+        """Create an acme account.
+
+        :param str name: The account name
+        :param str acme_server: The acme account server name (URL)
+        :param int org_id: The ID of the organization to associate the acme account with
+        :param dict ev_details: The EV details for the acme account
+
+        :return dict: The creation result
+        """
+        data = {
+            'name': name,
+            'acmeServer': acme_server,
+            'organizationId': org_id,
+            'evDetails': ev_details or {}
+        }
+
+        result = self._client.post(self._api_url, data=data)
+
+        # for status >= 400, HTTPError is raised
+        if result.status_code != 201:
+            raise ACMEAccountCreationResponseError(
+                "Unexpected HTTP status {}".format(result.status_code)
+            )
+        try:
+            loc = result.headers['Location']
+            acme_id = re.search(r'/([0-9]+)$', loc)[1]
+        # result.headers lookup fails
+        except KeyError as exc:
+            raise ACMEAccountCreationResponseError(
+                "Response does not include a Location header"
+            ) from exc
+        # re.search does not match, at all or the first group
+        except (TypeError, IndexError) as exc:
+            raise ACMEAccountCreationResponseError(
+                "Did not find an ACME ID in Response Location URL: {}".format(
+                    loc)
+            ) from exc
+        return {'id': int(acme_id)}
+
+    def update(self, acme_id, name):
+        """Update an acme account.
+
+        :param int acme_id: The ID of the acme account to update
+        :param str name: The account name
+
+        :return bool: Update success or failure
+        """
+        data = {
+            'name': name
+        }
+        url = self._url(str(acme_id))
+        result = self._client.put(url, data=data)
+
+        return result.ok
+
+    def delete(self, acme_id):
+        """Delete an acme account.
+
+        :param int acme_id: The ID of the acme account to delete
+
+        :return bool: Deletion success or failure
+        """
+        url = self._url(str(acme_id))
+        result = self._client.delete(url)
+
+        return result.ok
+
+    def add_domains(self, acme_id, domains):
+        """Add domains to an acme account.
+
+        :param int acme_id: The ID of the acme account to add domains to
+        :param list domains: The domains to add
+
+        :return dict: A dictionary containing a list of domains not added
+        """
+        data = {
+            'domains': [
+                {'name': domain}
+                for domain in domains
+            ]
+        }
+        url = self._url('/{}/domains'.format(acme_id))
+        result = self._client.post(url, data=data)
+
+        return result.json()
+
+    def remove_domains(self, acme_id, domains):
+        """Remove domains from an acme account.
+
+        :param int acme_id: The ID of the acme account to remove domains from
+        :param list domains: The domains to remove
+
+        :return dict: A dictionary containing a list of domains not removed
+        """
+        data = {
+            'domains': [
+                {'name': domain}
+                for domain in domains
+            ]
+        }
+        url = self._url('/{}/domains'.format(acme_id))
+        # Client().delete does not accept json, so work around it
+        result = self._client.session.request(
+            'DELETE',
+            url,
+            json=data
+        )
+        result.raise_for_status()
+
+        return result.json()

--- a/cert_manager/client.py
+++ b/cert_manager/client.py
@@ -167,7 +167,7 @@ class Client(object):
         :param dict data: A dictionary with the data to use for the body of the PUT
         :return obj: A requests.Response object received as a response
         """
-        result = self.__session.put(url, data=data, headers=headers)
+        result = self.__session.put(url, json=data, headers=headers)
         # Raise an exception if the return code is in an error range
         result.raise_for_status()
 

--- a/tests/test_acme.py
+++ b/tests/test_acme.py
@@ -1,0 +1,735 @@
+# -*- coding: utf-8 -*-
+"""Define the cert_manager.acme.ACMEAccount unit tests."""
+# Don't warn about things that happen as that is part of unit testing
+# pylint: disable=protected-access
+# pylint: disable=no-member
+
+from functools import wraps
+
+from requests.exceptions import HTTPError
+import responses
+from testtools import TestCase
+
+from cert_manager.acme import ACMEAccount, ACMEAccountCreationResponseError
+
+from .lib.testbase import ClientFixture
+
+
+class TestACMEAccount(TestCase):  # pylint: disable=too-few-public-methods
+    """Serve as a Base class for all tests of the ACMEAccount class."""
+
+    @property
+    def api_url(self):
+        """Return the base ACME Account URL for the default API version"""
+        return self.get_api_url()
+
+    def get_api_url(self, api_version='v1'):
+        """Return the base ACME Account URL for a particular API version"""
+        return '{}/acme/{}/account'.format(
+            self.cfixt.base_url,
+            api_version
+        )
+
+    def get_acme_account_url(self, acme_id, **kwargs):
+        """Return the ACME Account URL for the specified acme_id"""
+        return '{}/{}'.format(
+            self.get_api_url(**kwargs),
+            acme_id
+        )
+
+    def get_valid_response_entry(self, acme_id):
+        """Return the first entry in valid_response with a matching acme_id"""
+        for entry in self.valid_response:
+            if entry['id'] == acme_id:
+                return entry
+        raise KeyError('id {} not found in valid_response'.format(acme_id))
+
+    def get_acme_account_data(self, acme_id, domains=None):
+        """Return a matching entry from valid_response as ACME account data,
+        i.e. with SCM domains (empty by default)"""
+        valid_response = self.get_valid_response_entry(acme_id).copy()
+        valid_response.setdefault('domains', domains or [])
+        return valid_response
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Initialize the class."""
+        # Call the inherited setUp method
+        super().setUp()
+
+        # Make sure the Client fixture is created and setup
+        self.cfixt = self.useFixture(ClientFixture())
+        self.client = self.cfixt.client
+
+        self.org_id = 1234
+
+        self.base_params = {
+            'organizationId': str(self.org_id)
+        }
+
+        # Setup a test response one would expect normally
+        self.valid_response = [
+            {
+                'id': 1234,
+                'name': 'api_account1',
+                'status': 'pending',
+                'macKey': 'wtHoOUf8lyPFryvee2vFD8YsMLlhxQVOtNz2hwmTIJLfXauERXqYqzzxcA7b2Dpah84wjchbR8N1FhbFyrBAot',
+                'macId': '1SiwNov7jxsUQf3osQD2R4',
+                'acmeServer': 'https://acme.sectigo.com/v2/OV',
+                'organizationId': self.org_id,
+                'certValidationType': 'OV',
+                'accountId': '1SiwNov7jxsUQf3osQD2R4',
+                'ovOrderNumber': 387134123,
+                'contacts': '',
+                'evDetails': {}
+            },
+            {
+                'id': 4321,
+                'name': 'api_account2',
+                'status': 'valid',
+                'macKey': 'Xk9R79FfbdtNzUVRPDvX161NMSgG4WSjgni6grcaYAYUpRrAXfW69acFrajud03nSMONzIvbAGHiVxULSnmWgv',
+                'macId': 'mZLT4rsopz1veRo9S6IWhQ',
+                'acmeServer': 'https://acme.sectigo.com/v2/OV',
+                'organizationId': self.org_id,
+                'certValidationType': 'OV',
+                'accountId': 'mZLT4rsopz1veRo9S6IWhQ',
+                'ovOrderNumber': 387134123,
+                'contacts': '',
+                'evDetails': {}
+            },
+            {
+                'id': 4322,
+                'name': 'api_account3',
+                'status': 'pending',
+                'macKey': 'nupONsz5B8Nvl8eccd3yFiiVPvPCWXUWMBo0oCcT2gPYAs07yGDhF7UXN8esFHd9kt5I5pMgdR3s443V1EAvsA',
+                'macId': 'n4QsTzHBKSIFu3D7nTxzY8',
+                'acmeServer': 'https://acme.sectigo.com/v2/EV',
+                'organizationId': self.org_id,
+                'certValidationType': 'EV',
+                'accountId': 'n4QsTzHBKSIFu3D7nTxzY8',
+                'ovOrderNumber': 0,
+                'contacts': '',
+                'evDetails': {
+                    'orgName': 'Example Org',
+                    'orgCountry': 'EX',
+                    'postOfficeBox': '',
+                    'orgAddress1': 'Example Address',
+                    'orgAddress2': '',
+                    'orgAddress3': '',
+                    'orgLocality': 'Example Locality',
+                    'orgStateOrProvince': 'Example State',
+                    'orgPostalCode': '12345',
+                    'orgJoiState': '',
+                    'orgJoiLocality': '',
+                    'assumedName': '',
+                    'dateOfIncorporation': '',
+                    'companyNumber': ''
+                }
+            }
+        ]
+
+        # Setup JSON to return in an error
+        self.error_response = {"description": "acme error"}
+
+    def match_url_with_qs(self, url, extra_params=None, api_url=None):
+        """Check that a URL containing a query string matches
+        the base self.api_url and the query params contain self.base_params
+        and extra_params
+
+        :param string url: The URL to check
+        :param dict extra_params: The params the query string must contain, in addition to self.base_params
+        :param string api_url: Override self.api_url
+        """
+        api_url = api_url or self.api_url
+        (scheme, netloc, path, query_string, _) = responses.urlsplit(url)
+        url_plain = responses.urlunsplit((scheme, netloc, path, None, None))
+        self.assertEqual(url_plain, api_url)
+        params = dict(responses.parse_qsl(query_string))
+        match_params = self.base_params.copy()
+        match_params.update(extra_params or {})
+        self.assertDictContainsSubset(match_params, params)
+
+
+class TestInit(TestACMEAccount):
+    """Test the class initializer."""
+
+    def test_need_client(self):
+        """The class should raise an exception without a client parameter."""
+        self.assertRaises(TypeError, ACMEAccount)
+
+
+class TestAll(TestACMEAccount):
+    """Test the .all method."""
+
+    @responses.activate
+    def test_init_param(self):
+        """The URL should change if api_version is passed as a parameter to
+        class initialization."""
+        # Set a new version
+        version = "v3"
+        api_url = self.get_api_url(api_version=version)
+
+        # Setup the mocked response
+        responses.add(responses.GET, api_url, json=self.valid_response,
+                      status=200, match_querystring=False)
+
+        acme = ACMEAccount(client=self.client, api_version=version)
+        data = acme.all(self.org_id)
+
+        # Verify all the query information
+        # There should only be one call the first time "all" is called.
+        # Due to pagination, this is only guaranteed as long as the number of
+        # entries returned is less than the page size
+        self.assertEqual(len(responses.calls), 1)
+        self.match_url_with_qs(responses.calls[0].request.url, api_url=api_url)
+        self.assertEqual(data, self.valid_response)
+
+    @responses.activate
+    def test_bad_http(self):
+        """The function should raise an HTTPError exception if acme accounts cannot be retrieved from the API."""
+        # Setup the mocked response
+        responses.add(responses.GET, self.api_url, json=self.error_response,
+                      status=404, match_querystring=False)
+
+        acme = ACMEAccount(client=self.client)
+        self.assertRaises(HTTPError, acme.all, self.org_id)
+
+        # Verify all the query information
+        self.assertEqual(len(responses.calls), 1)
+        self.match_url_with_qs(responses.calls[0].request.url)
+
+    @responses.activate
+    def test_cached(self):
+        """The function should return all the data, but should not query the API twice."""
+        # Setup the mocked response, refrain from matching the query string
+        responses.add(responses.GET, self.api_url, json=self.valid_response,
+                      status=200, match_querystring=False)
+
+        acme = ACMEAccount(client=self.client)
+        acme.all(self.org_id)
+        data = acme.all(self.org_id)
+
+        # Verify all the query information
+        # There should only be one call the first time "all" is called.
+        # Due to pagination, this is only guaranteed as long as the number of
+        # entries returned is less than the page size
+        self.assertEqual(len(responses.calls), 1)
+        self.match_url_with_qs(responses.calls[0].request.url)
+        self.assertEqual(data, self.valid_response)
+
+    @responses.activate
+    def test_forced(self):
+        """The function should return all the data, but should query the API twice."""
+        # Setup the mocked response, refrain from matching the query string
+        responses.add(responses.GET, self.api_url, json=self.valid_response,
+                      status=200, match_querystring=False)
+
+        acme = ACMEAccount(client=self.client)
+        acme.all(self.org_id, force=True)
+        data = acme.all(self.org_id, force=True)
+
+        # Verify all the query information
+        # There should only be one call the first time "all" is called.
+        # Due to pagination, this is only guaranteed as long as the number of
+        # entries returned is less than the page size
+        self.assertEqual(len(responses.calls), 2)
+        self.match_url_with_qs(responses.calls[0].request.url)
+        self.match_url_with_qs(responses.calls[1].request.url)
+        self.assertEqual(data, self.valid_response)
+
+    def test_need_org_id(self):
+        """The function should raise an exception without an org_id parameter."""
+        acme = ACMEAccount(client=self.client)
+        self.assertRaises(TypeError, acme.all)
+
+
+def _test_find_test_factory(params=None):
+    params = params or {}
+    params_to_api = ACMEAccount._find_params_to_api
+    api_params = {
+        params_to_api[k]: params[k]
+        for k in params
+    }
+
+    @responses.activate
+    def generic_test(self):
+        """Generic test for .find request parameters/response fields"""
+        api_params[params_to_api['org_id']] = str(self.org_id)
+        valid_response = [
+            entry for entry in self.valid_response
+            if all([
+                    str(entry[k]).lower().find(str(api_params[k]).lower()) != -1
+                    for k in api_params
+            ])
+        ]
+        # Setup the mocked response
+        responses.add(responses.GET, self.api_url, json=valid_response,
+                      status=200, match_querystring=False)
+
+        acme = ACMEAccount(client=self.client)
+        data = acme.find(self.org_id, **params)
+
+        # Verify all the query information
+        # There should only be one call when "find" is called.
+        # Due to pagination, this is only guaranteed as long as the number of
+        # entries returned is less than the page size
+        self.assertEqual(len(responses.calls), 1)
+        self.match_url_with_qs(
+            responses.calls[0].request.url,
+            api_params
+        )
+        self.assertEqual(data, valid_response)
+    return generic_test
+
+
+class TestFind(TestACMEAccount):
+    """Test the .find method."""
+
+    test_name = _test_find_test_factory({'name': 'api_account1'})
+    test_name.__doc__ = """The function should return all the data about the
+    matched acme account name(s)."""
+
+    test_acme_server = _test_find_test_factory(
+        {'acme_server': 'https://acme.sectigo.com/v2/OV'})
+    test_acme_server.__doc__ = """The function should return all the data about
+    the matched acme account server(s)."""
+
+    test_cert_validation_type = _test_find_test_factory(
+        {'cert_validation_type': 'EV'})
+    test_cert_validation_type.__doc__ = """The function should return all the
+    data about the matched acme account validation type(s)."""
+
+    test_cert_status = _test_find_test_factory({'status': 'Valid'})
+    test_cert_status.__doc__ = """The function should return all the data about
+    the matched acme account status(es)."""
+
+    test_ne_server_and_cert_validation_type = _test_find_test_factory({
+        'acme_server': 'https://acme.sectigo.com/v2/OV',
+        'cert_validation_type': 'EV'
+    })
+    test_ne_server_and_cert_validation_type.__doc__ = """The function should
+    return an empty list if the acme account server and vaildation type do not
+    match."""
+
+    test_ne_name = _test_find_test_factory({'name': 'no such account'})
+    test_ne_name.__doc__ = """The function should return an empty list if the
+    acme account name does not match."""
+
+    test_ne_server = _test_find_test_factory(
+        {'acme_server': 'https://acme.sectigo.com/v2/XYZ'})
+    test_ne_server.__doc__ = """The function should return an empty list if the
+    acme account server does not match."""
+
+    test_no_params = _test_find_test_factory()
+    test_no_params.__doc__ = """The function should return the entire list of
+    acme accounts if no parameters are passed."""
+
+    def test_need_org_id(self):
+        """The function should raise an exception without an org_id parameter."""
+        acme = ACMEAccount(client=self.client)
+        self.assertRaises(TypeError, acme.find)
+
+
+class TestGet(TestACMEAccount):
+    """Test the .get method."""
+
+    def test_need_acme_id(self):
+        """The function should raise an exception without an acme_id parameter."""
+        acme = ACMEAccount(client=self.client)
+        self.assertRaises(TypeError, acme.get)
+
+    @responses.activate
+    def test_acme_id(self):
+        """The function should return all the data about the specified ACME ID."""
+        acme_id = 1234
+        api_url = self.get_acme_account_url(acme_id)
+        valid_response = self.get_acme_account_data(acme_id)
+
+        # Setup the mocked response
+        responses.add(responses.GET, api_url, json=valid_response, status=200)
+
+        acme = ACMEAccount(client=self.client)
+        data = acme.get(acme_id)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, api_url)
+        self.assertEqual(data, valid_response)
+
+    @responses.activate
+    def test_ne_acme_id(self):
+        """The function should raise an HTTPError exception if the specified ACME ID does not exist."""
+        acme_id = 2345
+        api_url = self.get_acme_account_url(acme_id)
+
+        # Setup the mocked response
+        responses.add(responses.GET, api_url, json=self.error_response,
+                      status=404)
+
+        acme = ACMEAccount(client=self.client)
+        self.assertRaises(HTTPError, acme.get, acme_id)
+
+
+def _test_create_test_factory(acme_id=1234, header='location', **kwargs):
+    params = ['name', 'acmeServer', 'organizationId', 'evDetails']
+
+    def wrapper(func):
+        @wraps(func)
+        def wrapped_func(self):
+            location = kwargs.get('location',
+                                  self.get_acme_account_url(acme_id))
+            response_headers = {
+                header: location
+            }
+            acme_entry = self.get_valid_response_entry(acme_id)
+            args = [
+                acme_entry[param]
+                for param in params
+            ]
+            request_params = {
+                param: acme_entry[param]
+                for param in acme_entry
+                if param in params
+            }
+            return func(self, acme_id, response_headers, args, request_params)
+        return wrapped_func
+    return wrapper
+
+
+class TestCreate(TestACMEAccount):
+    """Test the .create method."""
+
+    def test_need_params(self):
+        """
+        The function should raise an exception when called without required
+        parameters.
+        """
+
+        acme = ACMEAccount(client=self.client)
+        # missing name, acme_server, org_id
+        self.assertRaises(TypeError, acme.create)
+        # missing acme_server, org_id
+        self.assertRaises(TypeError, acme.create, 'name')
+        # missing org_id
+        self.assertRaises(TypeError, acme.create, 'name', 'acme_server')
+
+    @responses.activate
+    @_test_create_test_factory()
+    def test_create_success(self, acme_id, response_headers, args, request_params):
+        """The function should return the created ACME ID."""
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, headers=response_headers,
+                      match=[responses.json_params_matcher(request_params)],
+                      status=201)
+
+        acme = ACMEAccount(client=self.client)
+        response = acme.create(*args)
+
+        self.assertEqual(response, {'id': acme_id})
+
+    @responses.activate
+    @_test_create_test_factory()
+    def test_create_failure_http_error(self, _, __, args, request_params):
+        """
+        The function should return an error code and description if the ACME
+        Account creation failed.
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, json=self.error_response,
+                      match=[responses.json_params_matcher(request_params)],
+                      status=400)
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(HTTPError, acme.create, *args)
+
+    @responses.activate
+    @_test_create_test_factory()
+    def test_create_failure_http_status_unexpected(self, _, __, args,
+                                                   request_params):
+        """
+        The function should return an error code and description if the ACME
+        Account creation failed with ACMEAccountCreationResponseError
+        (unexpected HTTP status code).
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, json=self.error_response,
+                      match=[responses.json_params_matcher(request_params)],
+                      status=200)  # unexpected status
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(ACMEAccountCreationResponseError, acme.create,
+                          *args)
+
+    @responses.activate
+    @_test_create_test_factory(header='NotYourHeader')
+    def test_create_failure_missing_location_header(self, _, response_headers,
+                                                    args, request_params):
+        """
+        The function should return an error code and description if the ACME
+        Account creation failed with ACMEAccountCreationResponseError
+        (no Location header in response).
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, json=self.error_response,
+                      headers=response_headers,
+                      match=[responses.json_params_matcher(request_params)],
+                      status=201)
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(ACMEAccountCreationResponseError, acme.create,
+                          *args)
+
+    @responses.activate
+    @_test_create_test_factory(location='not_an_ACME_account_URL')
+    def test_create_failure_acme_id_not_found(self, _, response_headers, args,
+                                              request_params):
+        """
+        The function should return an error code and description if the ACME
+        Account creation failed with ACMEAccountCreationResponseError
+        (ACME ID not found in response).
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, json=self.error_response,
+                      headers=response_headers,
+                      match=[responses.json_params_matcher(request_params)],
+                      status=201)
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(ACMEAccountCreationResponseError, acme.create,
+                          *args)
+
+
+def _test_update_delete_test_factory(func):
+    acme_id = 1234
+    new_name = 'api_account1_new_name'
+    if func.__name__.find('test_update') == 0:
+        args = (acme_id, new_name)
+    else:
+        args = (acme_id,)
+
+    @wraps(func)
+    def wrapped_func(self):
+        return func(self, *args)
+    return wrapped_func
+
+
+class TestUpdate(TestACMEAccount):
+    """Test the .update method."""
+
+    def test_need_params(self):
+        """
+        The function should raise an exception when called without required
+        parameters.
+        """
+
+        acme = ACMEAccount(client=self.client)
+        # missing acme_id, name
+        self.assertRaises(TypeError, acme.create)
+        # missing name
+        self.assertRaises(TypeError, acme.create, 1234)
+
+    @responses.activate
+    @_test_update_delete_test_factory
+    def test_update_success(self, acme_id, new_name):
+        """The function should return True if the update succeeded."""
+
+        api_url = self.get_acme_account_url(acme_id)
+
+        # Setup the mocked response
+        responses.add(responses.PUT, api_url, status=200)
+
+        acme = ACMEAccount(client=self.client)
+        response = acme.update(acme_id, new_name)
+
+        self.assertEqual(True, response)
+
+    @responses.activate
+    @_test_update_delete_test_factory
+    def test_update_failure_http_error(self, acme_id, new_name):
+        """
+        The function should raise an HTTPError exception if the update failed.
+        """
+
+        api_url = self.get_acme_account_url(acme_id)
+
+        # Setup the mocked response
+        responses.add(responses.PUT, api_url, status=400)
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(HTTPError, acme.update, acme_id, new_name)
+
+
+class TestDelete(TestACMEAccount):
+    """Test the .delete method."""
+
+    def test_need_params(self):
+        """
+        The function should raise an exception when called without required
+        parameters.
+        """
+
+        acme = ACMEAccount(client=self.client)
+        # missing acme_id
+        self.assertRaises(TypeError, acme.delete)
+
+    @responses.activate
+    @_test_update_delete_test_factory
+    def test_delete_success(self, acme_id):
+        """The function should return True if the deletion succeeded."""
+
+        api_url = self.get_acme_account_url(acme_id)
+
+        # Setup the mocked response
+        responses.add(responses.DELETE, api_url, status=204)
+
+        acme = ACMEAccount(client=self.client)
+        response = acme.delete(acme_id)
+
+        self.assertEqual(True, response)
+
+    @responses.activate
+    @_test_update_delete_test_factory
+    def test_delete_failure_http_error(self, acme_id):
+        """
+        The function should raise an HTTPError exception if the deletion
+        failed.
+        """
+
+        api_url = self.get_acme_account_url(acme_id)
+
+        # Setup the mocked response
+        responses.add(responses.DELETE, api_url, status=400)
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(HTTPError, acme.delete, acme_id)
+
+
+def _test_add_remove_domains_test_factory(func):
+    acme_id = 1234
+
+    @wraps(func)
+    def wrapped_func(self):
+        acme_data = self.get_acme_account_data(acme_id, domains=[
+            'example.com',
+            'example.org'
+        ])
+        request_domains = acme_data['domains']
+        response_domains = ['example.com']
+        api_url = '{}/domains'.format(self.get_acme_account_url(acme_id))
+        if func.__name__.find('test_add') == 0:
+            resp_key = 'notAddedDomains'
+        else:
+            resp_key = 'notRemovedDomains'
+        args = (acme_id, api_url, request_domains,
+                {resp_key: response_domains})
+        return func(self, *args)
+    return wrapped_func
+
+
+class TestAddDomains(TestACMEAccount):
+    """Test the .add_domains method."""
+
+    def test_need_params(self):
+        """
+        The function should raise an exception when called without required
+        parameters or domains argument is not a list
+        """
+
+        acme = ACMEAccount(client=self.client)
+        # missing acme_id, domains
+        self.assertRaises(TypeError, acme.add_domains)
+        # missing domains
+        self.assertRaises(TypeError, acme.add_domains, 1234)
+        # domains is not iterable
+        self.assertRaises(TypeError, acme.add_domains, 1234, None)
+
+    @responses.activate
+    @_test_add_remove_domains_test_factory
+    def test_add_domains_success(self, acme_id, api_url, req_domains, resp):
+        """
+        The function should return a dictionary containing a list of domains
+        not added.
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, api_url, json=resp, status=200)
+
+        acme = ACMEAccount(client=self.client)
+        response = acme.add_domains(acme_id, req_domains)
+
+        self.assertEqual(response, resp)
+
+    @responses.activate
+    @_test_add_remove_domains_test_factory
+    def test_add_domains_failure_http_error(self, acme_id, api_url,
+                                            req_domains, _):
+        """
+        The function should raise an HTTPError exception if the domain addition
+        failed.
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, api_url, status=400)
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(HTTPError, acme.add_domains, acme_id, req_domains)
+
+
+class TestRemoveDomains(TestACMEAccount):
+    """Test the .remove_domains method."""
+
+    def test_need_params(self):
+        """
+        The function should raise an exception when called without required
+        parameters or domains argument is not a list
+        """
+
+        acme = ACMEAccount(client=self.client)
+        # missing acme_id, domains
+        self.assertRaises(TypeError, acme.remove_domains)
+        # missing domains
+        self.assertRaises(TypeError, acme.remove_domains, 1234)
+        # domains is not iterable
+        self.assertRaises(TypeError, acme.remove_domains, 1234, None)
+
+    @responses.activate
+    @_test_add_remove_domains_test_factory
+    def test_remove_domains_success(self, acme_id, api_url, req_domains, resp):
+        """
+        The function should return a dictionary containing a list of domains
+        not removed.
+        """
+
+        # Setup the mocked response
+        responses.add(responses.DELETE, api_url, json=resp, status=200)
+
+        acme = ACMEAccount(client=self.client)
+        response = acme.remove_domains(acme_id, req_domains)
+
+        self.assertEqual(response, resp)
+
+    @responses.activate
+    @_test_add_remove_domains_test_factory
+    def test_remove_domains_failure_http_error(self, acme_id, api_url,
+                                               req_domains, _):
+        """
+        The function should raise an HTTPError exception if the domain removal
+        failed.
+        """
+
+        # Setup the mocked response
+        responses.add(responses.DELETE, api_url, status=400)
+
+        acme = ACMEAccount(client=self.client)
+
+        self.assertRaises(HTTPError, acme.remove_domains, acme_id, req_domains)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -9,6 +9,7 @@
 #
 
 import sys
+from urllib.parse import urlencode
 
 import mock
 from testtools import TestCase
@@ -325,6 +326,30 @@ class TestGet(TestClient):
             self.assertEqual(headers[head], responses.calls[0].request.headers[head])
 
     @responses.activate
+    def test_params(self):
+        """It should add passed parameters."""
+        # Setup the mocked response
+        json_data = {"some": "data"}
+        responses.add(responses.GET, self.test_url, json=json_data, status=200,
+                      match_querystring=False)
+
+        # Call the function with extra parameters
+        params = {"key": "value"}
+        resp = self.client.get(self.test_url, params=params)
+        (scheme, netloc, path, query_string, _) = responses.urlsplit(
+            responses.calls[0].request.url)
+        url_plain = responses.urlunsplit((scheme, netloc, path, None, None))
+
+        # Verify all the query information
+        self.assertEqual(resp.json(), json_data)
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(url_plain, self.test_url)
+        self.assertDictContainsSubset(
+            params,
+            dict(responses.parse_qsl(query_string))
+        )
+
+    @responses.activate
     def test_failure(self):
         """It should raise an HTTPError exception if an error status code is returned."""
         # Setup the mocked response
@@ -337,6 +362,64 @@ class TestGet(TestClient):
         # Still make sure it actually did a query and received a result
         self.assertEqual(len(responses.calls), 1)
         self.assertEqual(responses.calls[0].request.url, self.test_url)
+
+
+class TestGetPaginated(TestClient):
+    """Test the get_paginated method."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Initialize the class."""
+        # Call the inherited setUp method
+        super().setUp()
+
+        # An example URL to use in testing
+        self.test_url = self.cfixt.base_url + "/test/url"
+
+    @responses.activate
+    def test_success(self):
+        """
+        It should trigger the expected number of GET requests with the expected
+        pagination parameters and yield the expected number of results.
+        """
+        # Setup the mocked response
+        json_data = {"some": "data"}
+        page_size = 3
+        total = 8
+        (*url_parts, _, _) = responses.urlsplit(self.test_url)
+        cursor = 0
+        response_count = 0
+        while cursor < total:
+            params = {'position': cursor, 'size': page_size}
+            url = responses.urlunsplit((*url_parts, urlencode(params), None))
+            delta = total - cursor
+            count = page_size if delta >= page_size else delta
+            resp = [json_data] * count
+            responses.add(responses.GET, url, json=resp, status=200)
+            response_count += 1
+            cursor += count
+
+        # Call the function
+        results = []
+        for result in self.client.get_paginated(self.test_url,
+                                                page_size=page_size):
+            results += result.json()
+
+        # Verify all the query information
+        self.assertEqual(results, [json_data] * total)
+        self.assertEqual(len(responses.calls), response_count)
+
+    @responses.activate
+    def test_no_json_response(self):
+        """It should yield no responses if the (first) response is not JSON."""
+        # Setup the mocked response
+        responses.add(responses.GET, self.test_url, body='no json', status=200,
+                      match_querystring=False)
+
+        # Call the function
+        res = self.client.get_paginated(self.test_url)
+
+        # Verify the result
+        self.assertEqual(len(list(res)), 0)
 
 
 class TestPost(TestClient):


### PR DESCRIPTION
* Add `cert_manager.client.Client.get_paginated()`, used for listing (searching) where Sectigo API doc implies use of pagination
* Let `Client.get()` also accept optional query parameters, so it can be reused with the new method
* Implement support for ACME account endpoint
* Add tests for ACME, `Client.get()` with parameters and `Client.get_paginated()`