### PR TITLE
Add support for sslcertificate list method

### DIFF
--- a/cert_manager/_certificates.py
+++ b/cert_manager/_certificates.py
@@ -145,6 +145,16 @@ class Certificates(Endpoint):
 
         return result.json()
 
+    def list(self, **kwargs):
+        """List of SSL certificates.
+        :param int size: Count of returned entries
+        :param int position: Position shift
+        """
+        url = self._url("/")
+        result = self._client.get(url, query=kwargs)
+
+        return result.json()
+
     def renew(self, cert_id):
         """Renew the certificate specified by the certificate ID.
 

--- a/cert_manager/_certificates.py
+++ b/cert_manager/_certificates.py
@@ -149,6 +149,8 @@ class Certificates(Endpoint):
         """List of SSL certificates.
         :param int size: Count of returned entries
         :param int position: Position shift
+        :return: List of certificates based on count and position
+        :rtype: list
         """
         url = self._url("/")
         result = self._client.get(url, query=kwargs)

--- a/cert_manager/client.py
+++ b/cert_manager/client.py
@@ -17,11 +17,11 @@ class Client(object):
     """Serve as a Base class for calls to the Sectigo Cert Manager APIs."""
 
     DOWNLOAD_TYPES = [
-        "base64",   # PKCS#7 Base64 encoded
-        "bin",      # PKCS#7 Bin encoded
-        "x509",     # X509, Base64 encoded
-        "x509CO",   # X509 Certificate only, Base64 encoded
-        "x509IO",   # X509 Intermediates/root only, Base64 encoded
+        "base64",  # PKCS#7 Base64 encoded
+        "bin",  # PKCS#7 Bin encoded
+        "x509",  # X509, Base64 encoded
+        "x509CO",  # X509 Certificate only, Base64 encoded
+        "x509IO",  # X509 Intermediates/root only, Base64 encoded
         "x509IOR",  # X509 Intermediates/root only Reverse, Base64 encoded
     ]
 
@@ -67,7 +67,9 @@ class Client(object):
             # Warn about using /api instead of /private/api if doing certificate auth
             if not re.search("/private", self.__base_url):
                 cert_uri = re.sub("/api", "/private/api", self.__base_url)
-                LOGGER.warning("base URI should probably be %s due to certificate auth", cert_uri)
+                LOGGER.warning(
+                    "base URI should probably be %s due to certificate auth", cert_uri
+                )
 
         else:
             # If we're not doing certificate auth, we need a password, so make sure an exception is raised if
@@ -130,14 +132,15 @@ class Client(object):
                     del self.__session.headers[head]
 
     @traffic_log(traffic_logger=LOGGER)
-    def get(self, url, headers=None):
+    def get(self, url, headers=None, query=None):
         """Submit a GET request to the provided URL.
 
         :param str url: A URL to query
         :param dict headers: A dictionary with any extra headers to add to the request
+        :param dict query: A dictionary with query parameters
         :return obj: A requests.Response object received as a response
         """
-        result = self.__session.get(url, headers=headers)
+        result = self.__session.get(url, headers=headers, params=query)
         # Raise an exception if the return code is in an error range
         result.raise_for_status()
 

--- a/cert_manager/client.py
+++ b/cert_manager/client.py
@@ -18,11 +18,11 @@ class Client(object):
 
     DOWNLOAD_TYPES = [
         "base64",  # PKCS#7 Base64 encoded
-        "bin",  # PKCS#7 Bin encoded
-        "x509",  # X509, Base64 encoded
+        "bin",     # PKCS#7 Bin encoded
+        "x509",    # X509, Base64 encoded
         "x509CO",  # X509 Certificate only, Base64 encoded
         "x509IO",  # X509 Intermediates/root only, Base64 encoded
-        "x509IOR",  # X509 Intermediates/root only Reverse, Base64 encoded
+        "x509IOR", # X509 Intermediates/root only Reverse, Base64 encoded
     ]
 
     def __init__(self, **kwargs):
@@ -67,9 +67,7 @@ class Client(object):
             # Warn about using /api instead of /private/api if doing certificate auth
             if not re.search("/private", self.__base_url):
                 cert_uri = re.sub("/api", "/private/api", self.__base_url)
-                LOGGER.warning(
-                    "base URI should probably be %s due to certificate auth", cert_uri
-                )
+                LOGGER.warning("base URI should probably be %s due to certificate auth", cert_uri)
 
         else:
             # If we're not doing certificate auth, we need a password, so make sure an exception is raised if
@@ -132,15 +130,15 @@ class Client(object):
                     del self.__session.headers[head]
 
     @traffic_log(traffic_logger=LOGGER)
-    def get(self, url, headers=None, query=None):
+    def get(self, url, headers=None, params=None):
         """Submit a GET request to the provided URL.
 
         :param str url: A URL to query
         :param dict headers: A dictionary with any extra headers to add to the request
-        :param dict query: A dictionary with query parameters
+        :param dict params: A dictionary with query parameters
         :return obj: A requests.Response object received as a response
         """
-        result = self.__session.get(url, headers=headers, params=query)
+        result = self.__session.get(url, headers=headers, params=params)
         # Raise an exception if the return code is in an error range
         result.raise_for_status()
 

--- a/cert_manager/client.py
+++ b/cert_manager/client.py
@@ -17,12 +17,12 @@ class Client(object):
     """Serve as a Base class for calls to the Sectigo Cert Manager APIs."""
 
     DOWNLOAD_TYPES = [
-        "base64",  # PKCS#7 Base64 encoded
-        "bin",     # PKCS#7 Bin encoded
-        "x509",    # X509, Base64 encoded
-        "x509CO",  # X509 Certificate only, Base64 encoded
-        "x509IO",  # X509 Intermediates/root only, Base64 encoded
-        "x509IOR", # X509 Intermediates/root only Reverse, Base64 encoded
+        "base64",   # PKCS#7 Base64 encoded
+        "bin",      # PKCS#7 Bin encoded
+        "x509",     # X509, Base64 encoded
+        "x509CO",   # X509 Certificate only, Base64 encoded
+        "x509IO",   # X509 Intermediates/root only, Base64 encoded
+        "x509IOR",  # X509 Intermediates/root only Reverse, Base64 encoded
     ]
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
This PR asks to add support for the ssl certificate list method (found simply at "/").  Since the back end does not provide any convenience for pagination we would leave that logic to callers of the client.

There are no tests, I wanted to first ask if I'm on the right track?

Eventually, I would like to implement the [SSL Certificates Report API](https://sectigo.com/uploads/audio/Certificate-Manager-20.1-Rest-API.html#_ssl_certificates_report):


From the [docs](https://sectigo.com/uploads/audio/Certificate-Manager-20.1-Rest-API.html#resource-SSL-list)

```
curl 'https://cert-manager.com/api/ssl/v1' -i -X GET \
    -H 'login: admin_customer14750' \
    -H 'Content-Type: application/json' \
    -H 'customerUri: cst14750' \
    -H 'password: password123'
 ```