### PR TITLE
Add custom_fields handling to Certificates.enroll method

### DIFF
--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -324,6 +324,10 @@ class TestEnroll(TestCertificates):
             {"id": 57, "name": "testName", "mandatory": False},
             {"id": 59, "name": "testName2", "mandatory": False},
         ]
+        self.cf_data_mandatory = [
+            {"id": 57, "name": "testName", "mandatory": True},
+            {"id": 59, "name": "testName2", "mandatory": False},
+        ]
 
     @staticmethod
     def fake_csr():
@@ -445,16 +449,12 @@ class TestEnroll(TestCertificates):
     def test_mandatory_custom_fields_missing(self):
         """It should raise an Exception if mandatory custom fields are missing """
         # Setup the mocked responses
-        cf_data_mandatory = [
-            {"id": 57, "name": "testName", "mandatory": True},
-            {"id": 59, "name": "testName2", "mandatory": False},
-        ]
         test_cf_missing_mandatory_field = [{"name": "testName2", "value": "testValue"}]
 
         # We need to mock the /types and /customFields URLs as well
         # since Certificates.types and Certificate.custom_fields are called from enroll
         responses.add(responses.GET, self.test_types_url, json=self.types_data, status=200)
-        responses.add(responses.GET, self.test_customfields_url, json=cf_data_mandatory, status=200)
+        responses.add(responses.GET, self.test_customfields_url, json=self.cf_data_mandatory, status=200)
         responses.add(responses.POST, self.test_url, json=self.test_result, status=200)
 
         # Call the function, expecting an exception

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -388,9 +388,8 @@ class TestEnroll(TestCertificates):
             org_id=self.test_org)
 
         # Verify all the query information
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 1)
         self.assertEqual(responses.calls[0].request.url, self.test_types_url)
-        self.assertEqual(responses.calls[1].request.url, self.test_customfields_url)
 
     @responses.activate
     def test_bad_term(self):
@@ -408,9 +407,8 @@ class TestEnroll(TestCertificates):
             org_id=self.test_org)
 
         # Verify all the query information
-        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(len(responses.calls), 1)
         self.assertEqual(responses.calls[0].request.url, self.test_types_url)
-        self.assertEqual(responses.calls[1].request.url, self.test_customfields_url)
 
     @responses.activate
     def test_mandatory_custom_fields_success(self):


### PR DESCRIPTION
Pull request for #24 
* Add a `custom_fields` parameter to Certificates.enroll
* Validate the structure and contents of the input list for that parameter
* Check the names of the custom fields provided against the list of
* valid custom fields registered with Sectigo
* Add additional tests to the TestCertificates case

I've tried to match your coding style and naming conventions as much as possible, but if I've missed anything or there's something you'd like me to tweak before you merge this, please let me know :)