### PR TITLE
Fix #26, JSONDecodeError when receiving HTTP 204 empty response from API

### DIFF
--- a/cert_manager/_certificates.py
+++ b/cert_manager/_certificates.py
@@ -212,8 +212,9 @@ class Certificates(Endpoint):
         data = {"csr": csr, "commonName": common_name, "subjectAlternativeNames": subject_alt_names, "reason": reason}
 
         result = self._client.post(url, data=data)
+        result.raise_for_status()
 
-        return result.json()
+        return {}
 
     def revoke(self, cert_id, reason=""):
         """Revoke the certificate specified by the certificate ID.
@@ -232,5 +233,6 @@ class Certificates(Endpoint):
         data = {"reason": reason}
 
         result = self._client.post(url, data=data)
+        result.raise_for_status()
 
-        return result.json()
+        return {}

--- a/tests/test_certificates.py
+++ b/tests/test_certificates.py
@@ -615,9 +615,9 @@ class TestRevoke(TestCertificates):
 
     @responses.activate
     def test_success(self):
-        """It should return JSON if a 200-level status code is returned with data."""
+        """It should return an empty dict if a 204 No Content response is returned."""
         # Setup the mocked responses
-        responses.add(responses.POST, self.test_url, json={}, status=204)
+        responses.add(responses.POST, self.test_url, body='', status=204)
 
         # Call the function
         resp = self.certobj.revoke(cert_id=self.test_id, reason="Because")
@@ -670,9 +670,9 @@ class TestReplace(TestCertificates):
 
     @responses.activate
     def test_success(self):
-        """It should return JSON if a 200-level status code is returned with data."""
+        """It should return an empty dict if a 204 No Content response is returned."""
         # Setup the mocked responses
-        responses.add(responses.POST, self.test_url, json={}, status=200)
+        responses.add(responses.POST, self.test_url, body='', status=200)
 
         # Call the function
         resp = self.certobj.replace(cert_id=self.test_id, csr=self.test_csr, common_name=self.test_cn,


### PR DESCRIPTION
Fix #26 

modifies `Certificates.revoke` and `Certificates.replace` to check for error code rather than trying to parse JSON out of an empty string

Updates unittests to match real-world API responses from SCM API