### PR TITLE
Add rust to package list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ COPY Pipfile* /usr/src/
 
 WORKDIR /usr/src
 
-ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 RUN apk update \
     && apk add bash gcc git libffi-dev libxml2-dev libxslt-dev musl-dev openssl-dev rust \
     && pip install pipenv==2018.11.26 --upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ COPY Pipfile* /usr/src/
 
 WORKDIR /usr/src
 
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 RUN apk update \
-    && apk add bash gcc git libffi-dev libxml2-dev libxslt-dev musl-dev openssl-dev \
+    && apk add bash gcc git libffi-dev libxml2-dev libxslt-dev musl-dev openssl-dev rust \
     && pip install pipenv==2018.11.26 --upgrade \
     && pipenv lock \
     && pipenv sync --dev \


### PR DESCRIPTION
Running `dev.sh` produces the following warning from `cryptography`:

>If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.', '  ', '  This package requires Rust >=1.41.0.', '  ----------------------------------------',

This adds rust to the apk list.  `dev.sh` now runs cleanly.

Alternative is to build with `ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1` and cryptography will build without the Rust code path.