### PR TITLE
Add support for domains endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 /*.egg-info
 /TemplateDemo/
 *.xml
+
+# VSCode settings
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "python.linting.flake8Enabled": false,
-    "python.linting.pylintEnabled": false,
-    "python.linting.enabled": true,
-    "autoDocstring.docstringFormat": "one-line-sphinx",
-    "python.linting.pylamaEnabled": true,
-    "python.linting.pycodestyleEnabled": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "python.linting.flake8Enabled": false,
+    "python.linting.pylintEnabled": false,
+    "python.linting.enabled": true,
+    "autoDocstring.docstringFormat": "one-line-sphinx",
+    "python.linting.pylamaEnabled": true,
+    "python.linting.pycodestyleEnabled": false
+}

--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ There are many API endpoints under Certificate Manager, and this library current
 * Organization (/organization)
 * Person (/person)
 * SSL (/ssl)
+* Client Administrator (/admin)
+* Domain (/domain)
 
 Other endpoints we hope to add in the near future:
 
-* Client Administrator (/admin)
 * Code Signing Certificates (/csod)
 * Custom Fields (/customField)
 * Domain Control Validation (/dcv)
 * Device Certificates (/device)
 * Discovery (/discovery)
-* Domain (/domain)
 * SMIME (/smime)
 
 ## Installing

--- a/cert_manager/__init__.py
+++ b/cert_manager/__init__.py
@@ -4,10 +4,11 @@
 from .acme import ACMEAccount
 from .admin import Admin
 from .client import Client
+from .domain import Domain
 from ._helpers import Pending
 from .organization import Organization
 from .person import Person
 from .smime import SMIME
 from .ssl import SSL
 
-__all__ = ["ACMEAccount", "Admin", "Client", "Organization", "Pending", "Person", "SMIME", "SSL"]
+__all__ = ["ACMEAccount", "Admin", "Client", "Domain", "Organization", "Pending", "Person", "SMIME", "SSL"]

--- a/cert_manager/_endpoint.py
+++ b/cert_manager/_endpoint.py
@@ -50,7 +50,7 @@ class Endpoint(object):
 
         return url
 
-    def _url(self, suffix):
+    def _url(self, *args):
         """Build the endpoint URL based on the API URL inside this object.
 
         :param str suffix: The suffix of the URL you wish to create i.e. for
@@ -58,7 +58,8 @@ class Endpoint(object):
         :return str: The full URL
         """
         url = self._api_url.rstrip("/")
-        url += "/" + suffix.strip("/")
+        for suffix in args:
+            url += "/" + suffix.strip("/")
         LOGGER.debug("URL created: %s", url)
 
         return url

--- a/cert_manager/client.py
+++ b/cert_manager/client.py
@@ -175,14 +175,15 @@ class Client(object):
         return result
 
     @traffic_log(traffic_logger=LOGGER)
-    def delete(self, url, headers=None):
+    def delete(self, url, headers=None, data=None):
         """Submit a DELETE request to the provided URL.
 
         :param str url: A URL to query
         :param dict headers: A dictionary with any extra headers to add to the request
+        :param dict data: A dictionary with the data to use for the body of the DELETE
         :return obj: A requests.Response object received as a response
         """
-        result = self.__session.delete(url, headers=headers)
+        result = self.__session.delete(url, json=data, headers=headers)
         # Raise an exception if the return code is in an error range
         result.raise_for_status()
 

--- a/cert_manager/domain.py
+++ b/cert_manager/domain.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""Define the cert_manager.domain.Domain class."""
+
+import re
+import logging
+from requests.exceptions import HTTPError
+
+from ._endpoint import Endpoint
+
+LOGGER = logging.getLogger(__name__)
+
+
+class DomainCreationResponseError(Exception):
+    """An error (other than HTTPError) occurred while processing Domain Creation API response"""
+
+
+class Domain(Endpoint):
+    """Query the Sectigo Cert Manager REST API for Domain data."""
+
+    def __init__(self, client, api_version="v1"):
+        """Initialize the class.
+
+        :param object client: An instantiated cert_manager.Client object
+        :param string api_version: The API version to use; the default is "v1"
+        """
+        super().__init__(client=client, endpoint="/domain", api_version=api_version)
+
+        self.__domains = None
+
+    def all(self, force=False):
+        """Return a list of domains from Sectigo.
+
+        :param bool force: If set to True, force refreshing the data from the API
+
+        :return list: A list of dictionaries representing the domains
+        """
+        if (self.__domains) and (not force):
+            return self.__domains
+
+        result = self._client.get(self._api_url)
+
+        self.__domains = result.json()
+
+        return self.__domains
+
+    def find(self, **kwargs):
+        """Return a list of domains matching the given parameters from Sectigo.
+
+        :param dict kwargs: A dictonary of parameters that will be passed to the API to execute teh search
+
+        :return list: A list of dictionaries representing the domains that match the given parameters
+        """
+        result = self._client.get(self._api_url, params=kwargs)
+
+        return result.json()
+
+    def count(self, **kwargs):
+        """Return a count of domains matching the given parameters from Sectigo.
+        If no parameters are given, the count will be of all domains
+
+        :return dict: Count of domains matching the given parameters
+        """
+        url = self._url("/count")
+        result = self._client.get(url, params=kwargs)
+
+        return result.json()
+
+    def create(self, name, org_id, cert_types, **kwargs):
+        """Create a domain
+
+        :param str name: Name of domain to create
+        :param int org_id: Organization Id to delegate the newly created domain to
+        :param list cert_types: Certificate types to delegate, allowed values are "SSL", "SMIME", and "CodeSign"
+        :param dict kwargs: A dictionary of additional fields to pass to the API
+
+        :return _type_: _description_
+        """
+        data = {
+            "name": name,
+            "delegations": [
+                {
+                    "orgId": org_id,
+                    "certTypes": cert_types
+                }
+            ]
+        }
+        for key, value in kwargs.items():
+            data[key] = value
+
+        try:
+            result = self._client.post(self._api_url, data=data)
+        except HTTPError as exc:
+            status_code = exc.response.status_code
+            if status_code == 400:
+                err_response = exc.response.json()
+                raise ValueError(err_response["description"]) from exc
+            raise exc
+
+        # for status >= 400, HTTPError is raised
+        if result.status_code != 201:
+            raise DomainCreationResponseError(f"Unexpected HTTP status {result.status_code}")
+        try:
+            loc = result.headers["Location"]
+            domain_id = re.search(r"/([0-9]+)$", loc)[1]
+        # result.headers lookup fails
+        except KeyError as exc:
+            raise DomainCreationResponseError(
+                "Response does not include a Location header"
+            ) from exc
+        # re.search does not match, at all or the first group
+        except (TypeError, IndexError) as exc:
+            raise DomainCreationResponseError(
+                f"Did not find an Domain ID in Response Location URL: {loc}"
+            ) from exc
+
+        return {"id": int(domain_id)}
+
+    def get(self, domain_id):
+        """Return a dictionary of domain information.
+
+        :param int domain_id: The ID of the domain to query
+
+        return dict: The domain information
+        """
+        url = self._url(str(domain_id))
+        result = self._client.get(url)
+
+        return result.json()
+
+    def delete(self, domain_id):
+        """Delete a domain.
+
+        :param int domain_id: The ID of the domain to delete
+
+        :return bool: Deletion success or failure
+        """
+        url = self._url(str(domain_id))
+        result = self._client.delete(url)
+
+        return result.ok
+
+    def activate(self, domain_id):
+        """Activate a domain.
+
+        :param int domain_id: The ID of the domain to activate
+
+        :return bool: activation success or failure
+        """
+        url = self._url(str(domain_id), "activate")
+        result = self._client.put(url)
+
+        return result.ok
+
+    def suspend(self, domain_id):
+        """Suspend a domain.
+
+        :param int domain_id: The ID of the domain to suspend
+
+        :return bool: suspension success or failure
+        """
+        url = self._url(str(domain_id), "suspend")
+        result = self._client.put(url)
+
+        return result.ok
+
+    def delegate(self, domain_id, org_id, cert_types):
+        """Delegate a domain.
+
+        :param int domain_id: The ID of the domain to delegate
+        :param int org_id: The ID of the organization to delegate the domain to
+        :param list cert_types: List of certificate types to delegate, allowed values are "SSL", "SMIME", and "CodeSign"
+
+        :return bool: delegation success or failure
+        """
+        url = self._url(str(domain_id), "delegation")
+        data = {
+            "orgId": org_id,
+            "certTypes": cert_types
+        }
+        result = self._client.post(url, data=data)
+
+        return result.ok
+
+    def remove_delegation(self, domain_id, org_id, cert_types):
+        """Remove a delegation for a domain.
+
+        :param int domain_id: The ID of the domain to remove delegation for
+        :param int org_id: The ID of the organization to remove delegation from
+        :param list cert_types: List of certificate types to remove delegation for,
+        allowed values are "SSL", "SMIME", and "CodeSign"
+
+        :return bool: delegation removal success or failure
+        """
+        url = self._url(str(domain_id), "delegation")
+        data = {
+            "orgId": org_id,
+            "certTypes": cert_types
+        }
+        result = self._client.delete(url, data=data)
+
+        return result.ok
+
+    def approve_delegation(self, domain_id, org_id):
+        """Approve a requested delegation
+
+        :param int domain_id: The ID of the domain to approve
+        :param int org_id: The ID of the organization requesting the delegation
+
+        :return bool: approval success or failure
+        """
+        url = self._url(str(domain_id), "delegation", "approve")
+        data = {
+            "orgId": org_id
+        }
+        result = self._client.post(url, data=data)
+
+        return result.ok
+
+    def reject_delegation(self, domain_id, org_id):
+        """Reject a requested delegation
+
+        :param int domain_id: The ID of the domain to approve
+        :param int org_id: The ID of the organization requesting the delegation
+
+        :return bool: True if request was rejected, False otherwise
+        """
+        url = self._url(str(domain_id), "delegation", "reject")
+        data = {
+            "orgId": org_id
+        }
+        result = self._client.post(url, data=data)
+
+        return result.ok

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -446,7 +446,7 @@ class TestDelete(TestAdmin):
         responses.add(responses.GET, self.api_url, json=self.valid_response, status=200)
 
         admin_id = 1234
-        api_url = api_url = f"{self.api_url}/{str(admin_id)}"
+        api_url = f"{self.api_url}/{str(admin_id)}"
 
         # Setup the mocked response
         responses.add(responses.DELETE, api_url, status=204)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -506,10 +506,11 @@ class TestDelete(TestClient):
     def test_success(self):
         """It should complete correctly if a 200-level status code is returned."""
         # Setup the mocked response
+        input_data = {"input": "data"}
         responses.add(responses.DELETE, self.test_url, status=204)
 
         # Call the function
-        self.client.delete(self.test_url)
+        self.client.delete(self.test_url, data=input_data)
 
         # Verify all the query information
         self.assertEqual(len(responses.calls), 1)
@@ -519,11 +520,12 @@ class TestDelete(TestClient):
     def test_headers(self):
         """It should add passed headers."""
         # Setup the mocked response
+        input_data = {"input": "data"}
         responses.add(responses.DELETE, self.test_url, status=204)
 
         # Call the function
         headers = {"newheader": "123"}
-        self.client.delete(self.test_url, headers=headers)
+        self.client.delete(self.test_url, headers=headers, data=input_data)
 
         # Verify all the query information
         self.assertEqual(len(responses.calls), 1)
@@ -537,10 +539,11 @@ class TestDelete(TestClient):
     def test_failure(self):
         """It should raise an HTTPError exception if a non-200 status code is returned."""
         # Setup the mocked response
+        input_data = {"input": "data"}
         responses.add(responses.DELETE, self.test_url, status=404)
 
         # Call the function, expecting an exception
-        self.assertRaises(HTTPError, self.client.delete, self.test_url)
+        self.assertRaises(HTTPError, self.client.delete, self.test_url, data=input_data)
 
         # Still make sure it actually did a query and received a result
         self.assertEqual(len(responses.calls), 1)

--- a/tests/test_domain.py
+++ b/tests/test_domain.py
@@ -1,0 +1,356 @@
+# -*- coding: utf-8 -*-
+"""Define the cert_manager.domain.Domain unit tests."""
+# Don't warn about things that happen as that is part of unit testing
+# pylint: disable=protected-access
+# pylint: disable=no-member
+
+import json
+
+from requests.exceptions import HTTPError
+from testtools import TestCase
+
+import responses
+
+from cert_manager.domain import Domain, DomainCreationResponseError
+
+from .lib.testbase import ClientFixture
+
+
+class TestDomain(TestCase):  # pylint: disable=too-few-public-methods
+    """Serve as a Base class for all tests of the Domain class."""
+
+    def setUp(self):  # pylint: disable=invalid-name
+        """Initialize the class."""
+        # Call the inherited setUp method
+        super().setUp()
+
+        # Make sure the Client fixture is created and setup
+        self.cfixt = self.useFixture(ClientFixture())
+        self.client = self.cfixt.client
+
+        self.api_url = f"{self.cfixt.base_url}/domain/v1"
+
+        # Setup a test response one would expect normally
+        self.valid_response = [
+            {"id": 1234, "name": "example.com"},
+            {"id": 4321, "name": "*.example.com"},
+            {"id": 4322, "name": "subdomain.example.com"},
+        ]
+
+        # Setup a test response for getting a specific Domain
+        self.valid_individual_response = self.valid_response[0]
+        self.valid_individual_response["status"] = "Active"
+
+        # Setup JSON to return in an error
+        self.error_response = {"description": "domain error"}
+
+
+class TestInit(TestDomain):
+    """Test the class initializer."""
+
+    @responses.activate
+    def test_param(self):
+        """The URL should change if api_version is passed as a parameter."""
+        # Set a new version
+        version = "v3"
+        api_url = f"{self.cfixt.base_url}/domain/{version}"
+
+        # Setup the mocked response
+        responses.add(responses.GET, api_url, json=self.valid_response, status=200)
+
+        domain = Domain(client=self.client, api_version=version)
+        data = domain.all()
+
+        # Verify all the query information
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, api_url)
+
+        self.assertEqual(data, self.valid_response)
+
+    def test_need_client(self):
+        """The class should raise an exception without a client parameter."""
+        self.assertRaises(TypeError, Domain)
+
+
+class TestAll(TestDomain):
+    """Test the .all method."""
+
+    @responses.activate
+    def test_cached(self):
+        """The function should return all the data, but should not query the API twice."""
+        # Setup the mocked response, refrain from matching the query string
+        responses.add(responses.GET, self.api_url, json=self.valid_response, status=200)
+
+        domain = Domain(client=self.client)
+        data = domain.all()
+        data = domain.all()
+
+        # Verify all the query information
+        # There should only be one call the first time "all" is called.
+        # Due to pagination, this is only guaranteed as long as the number of
+        # entries returned is less than the page size
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, self.api_url)
+        self.assertEqual(data, self.valid_response)
+
+    @responses.activate
+    def test_forced(self):
+        """The function should return all the data, but should query the API twice."""
+        # Setup the mocked response, refrain from matching the query string
+        responses.add(responses.GET, self.api_url, json=self.valid_response, status=200)
+
+        domain = Domain(client=self.client)
+        data = domain.all()
+        data = domain.all(force=True)
+
+        # Verify all the query information
+        # There should only be one call the first time "all" is called.
+        # Due to pagination, this is only guaranteed as long as the number of
+        # entries returned is less than the page size
+        self.assertEqual(len(responses.calls), 2)
+        self.assertEqual(responses.calls[0].request.url, self.api_url)
+        self.assertEqual(responses.calls[1].request.url, self.api_url)
+        self.assertEqual(data, self.valid_response)
+
+    @responses.activate
+    def test_bad_http(self):
+        """The function should raise an HTTPError exception if domain accounts cannot be retrieved from the API."""
+        # Setup the mocked response
+        responses.add(responses.GET, self.api_url, json=self.error_response, status=400)
+
+        domain = Domain(client=self.client)
+        self.assertRaises(HTTPError, domain.all)
+
+        # Verify all the query information
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, self.api_url)
+
+
+class TestGet(TestDomain):
+    """Test the .get method."""
+
+    @responses.activate
+    def test_need_domain_id(self):
+        """The function should raise an exception without an domain_id parameter."""
+
+        domain = Domain(client=self.client)
+        self.assertRaises(TypeError, domain.get)
+
+    @responses.activate
+    def test_domain_id(self):
+        """The function should return data about the specified Domain ID."""
+
+        domain_id = 1234
+        api_url = f"{self.api_url}/{str(domain_id)}"
+
+        # Setup the mocked response
+        responses.add(responses.GET, api_url, json=self.valid_individual_response, status=200)
+
+        domain = Domain(client=self.client)
+        data = domain.get(domain_id)
+
+        self.assertEqual(len(responses.calls), 1)
+        self.assertEqual(responses.calls[0].request.url, api_url)
+        self.assertEqual(data, self.valid_individual_response)
+
+    @responses.activate
+    def test_ne_domain_id(self):
+        """The function should raise an HTTPError exception if the specified Domain ID does not exist."""
+
+        domain_id = 2345
+        api_url = f"{self.api_url}/{str(domain_id)}"
+
+        # Setup the mocked response
+        responses.add(responses.GET, api_url, status=404)
+
+        domain = Domain(client=self.client)
+        self.assertRaises(HTTPError, domain.get, domain_id)
+
+
+class TestCreate(TestDomain):
+    """Test the .create method."""
+
+    @responses.activate
+    def test_need_params(self):
+        """
+        The function should raise an exception when called without required
+        parameters.
+        """
+
+        domain = Domain(client=self.client)
+        # Not going to check every permutation of missing parameters,
+        # but verify that something is required
+        self.assertRaises(TypeError, domain.create)
+
+    @responses.activate
+    def test_create_success(self):
+        """
+        The function should return the created domain ID,
+        as well as add all parameters to the request body
+        """
+
+        # Setup the mocked response
+        domain_id = 1234
+        location = f"{self.api_url}/{str(domain_id)}"
+        responses.add(responses.POST, self.api_url, headers={"Location": location}, status=201)
+
+        domain = Domain(client=self.client)
+        post_data = {
+            "name": "sub2.example.com",
+            "delegations": [{"orgId": 4321, "certTypes": ["SSL"]}]
+        }
+        response = domain.create("sub2.example.com", 4321, ["SSL"])
+
+        self.assertEqual(response, {"id": domain_id})
+        self.assertEqual(responses.calls[0].request.body, json.dumps(post_data).encode("utf8"))
+
+    @responses.activate
+    def test_create_success_optional_params(self):
+        """
+        The function should return the created domain ID when additional params are specified,
+        as well add the non-required parameters to the request body
+        """
+
+        # Setup the mocked response
+        domain_id = 1234
+        location = f"{self.api_url}/{str(domain_id)}"
+        responses.add(responses.POST, self.api_url, headers={"Location": location}, status=201)
+
+        domain = Domain(client=self.client)
+        post_data = {
+            "name": "sub2.example.com",
+            "delegations": [{"orgId": 4321, "certTypes": ["SSL"]}],
+            "description": "Example sub domain"
+        }
+        response = domain.create("sub2.example.com", 4321, ["SSL"], description="Example sub domain")
+
+        self.assertEqual(response, {"id": domain_id})
+        self.assertEqual(responses.calls[0].request.body, json.dumps(post_data).encode("utf8"))
+
+    @responses.activate
+    def test_create_failure_http_error(self):
+        """
+        The function should return an error code and description if the Domain
+        creation failed.
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, json=self.error_response,
+                      status=400)
+
+        domain = Domain(client=self.client)
+
+        create_args = {
+            "name": "sub2.example.com",
+            "org_id": 4321,
+            "cert_types": ["other"]
+        }
+        self.assertRaises(ValueError, domain.create, **create_args)
+
+    @responses.activate
+    def test_create_failure_http_status_unexpected(self):
+        """
+        The function should return an error code and description if the Domain
+        creation failed with DomainCreationResponseError
+        (unexpected HTTP status code).
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, json=self.error_response,
+                      status=200)
+
+        domain = Domain(client=self.client)
+
+        create_args = {
+            "name": "sub2.example.com",
+            "org_id": 4321,
+            "cert_types": ["SSL"]
+        }
+        self.assertRaises(DomainCreationResponseError, domain.create, **create_args)
+
+    @responses.activate
+    def test_create_failure_missing_location_header(self):
+        """
+        The function should return an error code and description if the Domain
+        creation failed with DomainCreationResponseError
+        (no Location header in response).
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, status=201)
+
+        domain = Domain(client=self.client)
+
+        create_args = {
+            "name": "sub2.example.com",
+            "org_id": 4321,
+            "cert_types": ["SSL"]
+        }
+        self.assertRaises(DomainCreationResponseError, domain.create, **create_args)
+
+    @responses.activate
+    def test_create_failure_domain_id_not_found(self):
+        """
+        The function should return an error code and description if the Domain
+        creation failed with DomainCreationResponseError
+        (Domain ID not found in response).
+        """
+
+        # Setup the mocked response
+        responses.add(responses.POST, self.api_url, headers={"Location": "not a url"}, status=201)
+
+        domain = Domain(client=self.client)
+
+        create_args = {
+            "name": "sub2.example.com",
+            "org_id": 4321,
+            "cert_types": ["SSL"]
+        }
+        self.assertRaises(DomainCreationResponseError, domain.create, **create_args)
+
+
+class TestDelete(TestDomain):
+    """Test the .delete method."""
+
+    @responses.activate
+    def test_need_params(self):
+        """
+        The function should raise an exception when called without required
+        parameters.
+        """
+
+        domain = Domain(client=self.client)
+        # missing domain_id
+        self.assertRaises(TypeError, domain.delete)
+
+    @responses.activate
+    def test_delete_success(self):
+        """The function should return True if the deletion succeeded."""
+
+        domain_id = 1234
+        api_url = api_url = f"{self.api_url}/{str(domain_id)}"
+
+        # Setup the mocked response
+        responses.add(responses.DELETE, api_url, status=200)
+
+        domain = Domain(client=self.client)
+        response = domain.delete(domain_id)
+
+        self.assertEqual(True, response)
+
+    @responses.activate
+    def test_delete_failure_http_error(self):
+        """
+        The function should raise an HTTPError exception if the deletion
+        failed.
+        """
+
+        domain_id = 1234
+        api_url = f"{self.api_url}/{str(domain_id)}"
+
+        # Setup the mocked response
+        responses.add(responses.DELETE, api_url, status=404)
+
+        domain = Domain(client=self.client)
+
+        self.assertRaises(HTTPError, domain.delete, domain_id)

--- a/tests/test_endpoint.py
+++ b/tests/test_endpoint.py
@@ -125,3 +125,15 @@ class TestUrl(TestEndpoint):
 
         # Make sure the values match
         self.assertEqual(end._url(suffix), url)
+
+    def test_multiple_args(self):
+        """Return the full API URL when multiple arguments are passed"""
+        end = Endpoint(client=self.client, endpoint=self.ep_path)
+
+        suffix1 = "help"
+        suffix2 = "1234"
+        suffix3 = "approve"
+        url = f"{self.api_url}/{suffix1}/{suffix2}/{suffix3}"
+
+        # Make sure the values match
+        self.assertEqual(end._url(suffix1, suffix2, suffix3), url)


### PR DESCRIPTION
Add support for all the domain endpoints.

The domain endpoint requires some URLs with multiple values in them that the current `_url` function couldn't handle, so I modified it to take a list of strings to create the URL.  I see in other cases where that's been needed, a constructed string has been passed into the parameter (like `url = self._url(f"/id/byEmail/{quoted_email}")` in person.py) but I didn't look until after I wrote that.  I'm fine with removing my change and building the URL manually, or going back and changing all instances where the method constructs the string to use my updated method.  I did add a test for the new functionality.

I also had to add support for a payload in the DELETE method, as some of the domain methods need that.  I expanded the test slightly to look like the POST tests.  I didn't see any test that explicitly checks to make sure the request payload is added to the request, but maybe that's covered implicitly elsewhere.

I updated the README to reflect that Admin and now Domain endpoints have been created.

Finally, since I accidentally committed my local vscode settings, I added the directory to .gitignore to prevent that from happening again to me or anyone else, if they use vscode.

