### PR TITLE
Dynamic api version

### DIFF
--- a/cert_manager/__init__.py
+++ b/cert_manager/__init__.py
@@ -10,6 +10,7 @@ from .person import Person
 from .report import Report
 from .smime import SMIME
 from .ssl import SSL
+from .dcv import DomainControlValidation
 
 __all__ = [
     "ACMEAccount", "Admin", "Client", "Domain", "Organization", "PendingError", "Person", "Report", "SMIME", "SSL"

--- a/cert_manager/_endpoint.py
+++ b/cert_manager/_endpoint.py
@@ -17,6 +17,7 @@ class Endpoint:
         """
         self._client = client
         self._api_version = api_version
+        self._endpoint = endpoint
         self._api_url = self.create_api_url(client.base_url, endpoint, self._api_version)
         self._expected_code = 201
         self._capture_err_code = 400
@@ -64,3 +65,13 @@ class Endpoint:
         LOGGER.debug("URL created: %s", url)
 
         return url
+
+    def _change_api_version(self, api_version):
+        """Change API version
+
+        :param str api_version: API version switch to
+        """
+        if (self._api_version == api_version):
+            return
+        self._api_version = api_version
+        self._api_url = self.create_api_url(self._client.base_url, self._endpoint, self._api_version)

--- a/cert_manager/dcv.py
+++ b/cert_manager/dcv.py
@@ -29,6 +29,8 @@ class DomainControlValidation(Endpoint):
 
         :return list: a list of DCV statuses
         """
+        self._change_api_version("v1")
+
         url = self._url("validation")
         result = self._client.get(url, params=kwargs)
 
@@ -45,6 +47,7 @@ class DomainControlValidation(Endpoint):
 
         :return list: the DCV status for the domain
         """
+        self._change_api_version("v2")
         url = self._url("validation", "status")
         data = {"domain": domain}
 
@@ -71,6 +74,8 @@ class DomainControlValidation(Endpoint):
             host: Where the validation will expect the CNAME to live on the server
             point: Where the CNAME should point to
         """
+        self._change_api_version("v1")
+
         url = self._url("validation", "start", "domain", "cname")
         data = {"domain": domain}
 
@@ -98,6 +103,8 @@ class DomainControlValidation(Endpoint):
             orderStatus: The status of the validation request
             message: An optional message to help with debugging
         """
+        self._change_api_version("v1")
+
         url = self._url("validation", "submit", "domain", "cname")
         data = {"domain": domain}
 

--- a/cert_manager/dcv.py
+++ b/cert_manager/dcv.py
@@ -43,6 +43,7 @@ class DomainControlValidation(Endpoint):
             position, size, domain, org, department, dcvStatus, orderStatus, expiresIn
 
         See
+        Latest API documentation (23.12): https://www.sectigo.com/knowledge-base/detail/Sectigo-Certificate-Manager-SCM-REST-API/kA01N000000XDkE
         https://www.sectigo.com/uploads/audio/Certificate-Manager-20.1-Rest-API.html#resources-dcv-status
 
         :return list: the DCV status for the domain
@@ -90,8 +91,59 @@ class DomainControlValidation(Endpoint):
 
         return result.json()
 
+    def start_validation_email(self, domain: str):
+        """Start Domain Control Validation using Email method.
+
+        :param string domain: The domain to validate
+        :return response: List of valid email addresses
+        """
+        self._change_api_version("v1")
+        url = self._url("validation", "start", "domain", "email")
+        data = {"domain": domain}
+
+        try:
+            result = self._client.post(url, data=data)
+        except HTTPError as exc:
+            status_code = exc.response.status_code
+            if status_code == HTTPStatus.BAD_REQUEST:
+                err_response = exc.response.json()
+                raise ValueError(err_response["description"]) from exc
+            raise exc
+
+        return result.json()
+
     def submit_validation_cname(self, domain: str):
         """Finish Domain Control Validation using the CNAME method.
+
+        See
+        https://www.sectigo.com/uploads/audio/Certificate-Manager-20.1-Rest-API.html#resources-dcv-submit-cname
+
+        :param string domain: The domain to validate
+        :param string email: validation email sent to
+
+        :return response: a dictionary containing
+            status: The status of the validation
+            orderStatus: The status of the validation request
+            message: An optional message to help with debugging
+        """
+        self._change_api_version("v1")
+
+        url = self._url("validation", "submit", "domain", "cname")
+        data = {"domain": domain}
+
+        try:
+            result = self._client.post(url, data=data)
+        except HTTPError as exc:
+            status_code = exc.response.status_code
+            if status_code == HTTPStatus.BAD_REQUEST:
+                err_response = exc.response.json()
+                raise ValueError(err_response["description"]) from exc
+            raise exc
+
+        return result.json()
+
+    def submit_validation_email(self, domain: str, email: str):
+        """Finish Domain Control Validation using the email method.
 
         See
         https://www.sectigo.com/uploads/audio/Certificate-Manager-20.1-Rest-API.html#resources-dcv-submit-cname
@@ -105,8 +157,9 @@ class DomainControlValidation(Endpoint):
         """
         self._change_api_version("v1")
 
-        url = self._url("validation", "submit", "domain", "cname")
-        data = {"domain": domain}
+        url = self._url("validation", "submit", "domain", "email")
+        data = {"domain": domain,
+                "email": email}
 
         try:
             result = self._client.post(url, data=data)


### PR DESCRIPTION
Allow method to change api version, so we can update the library to use current API version. (23.10)
See dcv.py how to use.

New methods:
- Endpoint._change_api_version
- dcv.start_validation_email
- dcv.submit_validation_email

